### PR TITLE
Harden workflows

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   determine_changes:
     name: Determine Changes and Version
@@ -18,6 +21,7 @@ jobs:
         # Depth setting is necessary for the semantic-version action.
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Determine version
         id: semantic-version
         uses: paulhatch/semantic-version@9f72830310d5ed81233b641ee59253644cd8a8fc # v6.0.2
@@ -44,17 +48,17 @@ jobs:
       - determine_changes
     name: Create New Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: ${{ needs.determine_changes.outputs.paths-changed == 'true' }}
     steps:
-      - name: Check out repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Publish new release
-        shell: bash
-        run: |
-          git tag ${{ needs.determine_changes.outputs.version-tag }} ${{ github.sha }}
-          git push origin ${{ needs.determine_changes.outputs.version-tag }}
-          echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-          gh release create ${{ needs.determine_changes.outputs.version-tag }} --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          VERSION_TAG: ${{ needs.determine_changes.outputs.version-tag }}
+          TARGET_SHA: ${{ github.sha }}
+        run: gh release create "$VERSION_TAG" --target "$TARGET_SHA" --generate-notes
 
   # There is no need for this job in CI, but PRs benefit from an existing cache, because they can use the cache from the main branch.
   warm_cache:
@@ -66,6 +70,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build dependencies
         uses: freckle/stack-action@acc59ce470bb6f7b20e1469d6c520a1b27a36818 # v5.7.17
@@ -87,6 +93,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Log in to Docker Hub
@@ -123,15 +131,18 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: ${{ github.workspace }}/source
+          persist-credentials: false
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ vars.GITOPS_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GITOPS_BOT_PRIVATE_KEY }}
           owner: nikitaDanilenko
           repositories: git-ops
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Check out GitOps repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -139,8 +150,11 @@ jobs:
           repository: nikitaDanilenko/git-ops
           token: ${{ steps.app-token.outputs.token }}
           path: ${{ github.workspace }}/git-ops
+          persist-credentials: false
 
       - name: Update templates and image tag
+        env:
+          VERSION: ${{ needs.determine_changes.outputs.version }}
         run: |
           # Careful: The target is called 'pubquiz' in GitOps, because it contains the entire application.
           GITOPS_DIR="${{ github.workspace }}/git-ops/pubquiz"
@@ -157,7 +171,6 @@ jobs:
           rsync -av --delete "$SOURCE_DIR/templates/postgres/" "$GITOPS_DIR/templates/postgres/"
 
           # Update image tag in GitOps values.yaml
-          VERSION="${{ needs.determine_changes.outputs.version }}"
           yq -i ".backend.image.tag = \"$VERSION\"" "$GITOPS_DIR/values.yaml"
 
       - name: Determine commit title

--- a/.github/workflows/verify-pull-request.yaml
+++ b/.github/workflows/verify-pull-request.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
@@ -19,6 +22,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Check changed paths
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: paths
@@ -45,6 +50,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Build and test
         uses: freckle/stack-action@acc59ce470bb6f7b20e1469d6c520a1b27a36818 # v5.7.17
@@ -63,6 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: source
+          persist-credentials: false
 
       - name: Check out GitOps repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -70,6 +78,7 @@ jobs:
           repository: nikitaDanilenko/git-ops
           path: git-ops
           sparse-checkout: pubquiz
+          persist-credentials: false
 
       - name: Copy templates to GitOps structure
         run: |
@@ -94,6 +103,7 @@ jobs:
       - test
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check test result
         run: |
@@ -112,6 +122,7 @@ jobs:
       - validate_templates
     if: always()
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Check template validation result
         run: |


### PR DESCRIPTION
Addresses zizmor findings: scoped permissions, persist-credentials disabled, expressions moved to env vars, App token narrowed. Release step rewritten to use `gh release create --target` (drops git push).