### PR TITLE
Disable Renovate for haskell Docker image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
     {
       "matchUpdateTypes": ["major"],
       "automerge": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["haskell"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Haskell base image version is coupled to the Stackage LTS resolver. Bumps must happen together, so leave them to the manual annual LTS reminder.