### PR TITLE
Serialize build-and-publish runs

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: build-and-publish
+  cancel-in-progress: false
+
 jobs:
   determine_changes:
     name: Determine Changes and Version


### PR DESCRIPTION
Adds concurrency group so merges to main queue rather than running in parallel. Avoids racing version bumps and GitOps PR creation.