### PR TITLE
Remove Renovate PR rate limits

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/build-and-publish.yaml:
+    ignore:
+      - 'unexpected key "queue"'

--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -10,6 +10,7 @@ permissions:
 concurrency:
   group: build-and-publish
   cancel-in-progress: false
+  queue: max
 
 jobs:
   determine_changes:

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+      - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca # v1.7.12
 
   zizmor:
     name: Zizmor

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
   ],
   "schedule": ["before 06:00 on monday"],
   "timezone": "Europe/Berlin",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "digest"],


### PR DESCRIPTION
Lets all available updates surface as PRs without rate-limiting through the dependency dashboard.