### PR TITLE
Emit LOG_SQL as Dhall Bool literal

### DIFF
--- a/deployment/templates/backend/deployment.yaml
+++ b/deployment/templates/backend/deployment.yaml
@@ -64,7 +64,7 @@ spec:
                   name: {{ .Values.secretName }}
                   key: organizer-user-hash
             - name: LOG_SQL
-              value: {{ .Values.backend.logSql | default false | quote }}
+              value: {{ if .Values.backend.logSql }}"True"{{ else }}"False"{{ end }}
           ports:
             - name: http
               containerPort: {{ .Values.backend.port }}


### PR DESCRIPTION
Helm's lowercase `true`/`false` failed Dhall's `Bool` parser, breaking backend startup.