### PR TITLE
Pin postgres major version in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,12 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": ["haskell"],
       "enabled": false
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Postgres major upgrades require a data migration (`pg_dump`/`pg_upgrade`); a silent Renovate bump from N to N+1 produces a CrashLoopBackOff on existing PVCs. This rule prevents Renovate from opening a major-bump PR for the postgres image, while still allowing minor/patch/digest updates. Triggered by a recent 16→18 incident in `londo`.

Mirrored to `londo` and `foodie`.